### PR TITLE
move extension methods of ByteString to String

### DIFF
--- a/src/TreeSitter-Famix-Integration/String.extension.st
+++ b/src/TreeSitter-Famix-Integration/String.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : 'ByteString' }
+Extension { #name : 'String' }
 
 { #category : '*TreeSitter-Famix-Integration' }
-ByteString >> hasNoLineReturnBetween: start and: end [
+String >> hasNoLineReturnBetween: start and: end [
 
 	^ (self copyFrom: start to: end) noneSatisfy: [ :character | character = Character lf or: [ character = Character cr ] ]
 ]
 
 { #category : '*TreeSitter-Famix-Integration' }
-ByteString >> hasOnlySpacesAndTabsBetween: start and: end [
+String >> hasOnlySpacesAndTabsBetween: start and: end [
 
 	^ (self copyFrom: start to: end) allSatisfy: [ :character | character isSpaceSeparator or: [ character = Character tab ] ]
 ]


### PR DESCRIPTION
When the source is too large, the class representing the string is not a ByteString anymore but change to a WideString instead. 
In that case, WideString does not understand those extension methods. I moved them higher in String so that both ByteString and WideString can understand them